### PR TITLE
make render pass compatible with Unity 2022

### DIFF
--- a/Assets/Scripts/BlurRenderPass.cs
+++ b/Assets/Scripts/BlurRenderPass.cs
@@ -13,7 +13,6 @@ public class BlurRenderPass : ScriptableRenderPass
 
     public bool Setup(ScriptableRenderer renderer)
     {
-        source = renderer.cameraColorTarget;
         blurSettings = VolumeManager.instance.stack.GetComponent<BlurSettings>();
         renderPassEvent = RenderPassEvent.BeforeRenderingPostProcessing;
 
@@ -39,6 +38,12 @@ public class BlurRenderPass : ScriptableRenderPass
         cmd.GetTemporaryRT(blurTex.id, cameraTextureDescriptor);
 
         base.Configure(cmd, cameraTextureDescriptor);
+    }
+
+    public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+    {
+        base.OnCameraSetup(cmd, ref renderingData);
+        source = renderingData.cameraData.renderer.cameraColorTarget;
     }
 
     public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)


### PR DESCRIPTION
fix "You can only call cameraColorTarget inside the scope of a ScriptableRenderPass. Otherwise the pipeline camera target texture might have not been created or might have already been disposed." error in Unity 2022